### PR TITLE
Feature/test20210623

### DIFF
--- a/notes/Code/ScriptLibraries/domiUtilsFE.lss
+++ b/notes/Code/ScriptLibraries/domiUtilsFE.lss
@@ -330,7 +330,7 @@ Function domiValidateOAuthToken() As Boolean
 	Set domi.Document = ndoc 
 
 	If domi.refreshAuthToken(False) Then 
-		Call nuidoc.Reload()
+		If nuidoc.EditMode Then Call nuidoc.Reload()
 		MessageBox |Your OAuth Token is Valid|, MB_ICONINFORMATION, |Success|
 		result = True 
 	Else
@@ -383,15 +383,15 @@ Function domiRevokeOAuthToken() As Boolean
 	Set domi.Document = ndoc 
 	
 	If domi.refreshAuthToken(False) Then
-		If domi.revokeAuthToken(False) Then
-			Call nuidoc.Reload()
+		If domi.revokeAuthToken(True) Then
+			Call nuidoc.Close()
 			MessageBox |Your OAUTH Token has been revoked|, MB_ICONINFORMATION, |Success|
 			result = True
 		Else
 			MessageBox |The token could not be revoked.|, MB_ICONEXCLAMATION, |Failed to Revoke your OAUTH Token.|
 		End If
 	Else 
-		MessageBox |The refresh token has already expired.|, MB_ICONEXCLAMATION, |OAUTH Token Already Expired.|
+		MessageBox |The refresh token has already expired or is invalid.|, MB_ICONEXCLAMATION, |OAUTH Token Not Valid.|
 	End If
 	
 	

--- a/notes/Forms/(domiSTLoginDlg).form
+++ b/notes/Forms/(domiSTLoginDlg).form
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <form name='(domiSTLoginDlg)' alias='domiSTLoginDlg' xmlns='http://www.lotus.com/dxl'
- version='11.0' maintenanceversion='1.0' replicaid='852586DC005D7BD2' publicaccess='false'
+ version='11.0' maintenanceversion='1.0' replicaid='852586FD00509207' publicaccess='false'
  designerversion='8.5.3' comment='dialog for initial login into ST Meeting server'
  inherit='true' renderpassthrough='true'>
-<noteinfo noteid='282' unid='63B8F0957714380B8525868D0048A2B0' sequence='6'>
+<noteinfo noteid='282' unid='63B8F0957714380B8525868D0048A2B0' sequence='3'>
 <created><datetime>20210303T081322,40-05</datetime></created>
-<modified><datetime dst='true'>20210521T131034,01-04</datetime></modified>
-<revised><datetime dst='true'>20210521T131034,00-04</datetime></revised>
-<lastaccessed><datetime dst='true'>20210521T131034,00-04</datetime></lastaccessed>
-<addedtofile><datetime dst='true'>20210521T130116,43-04</datetime></addedtofile></noteinfo>
+<modified><datetime dst='true'>20210623T104200,35-04</datetime></modified>
+<revised><datetime dst='true'>20210623T104200,34-04</datetime></revised>
+<lastaccessed><datetime dst='true'>20210623T104200,34-04</datetime></lastaccessed>
+<addedtofile><datetime dst='true'>20210623T104013,12-04</datetime></addedtofile></noteinfo>
 <updatedby><name>CN=Devin Olson/OU=USA/O=PNPHCL</name></updatedby>
 <wassignedby><name>CN=Devin Olson/OU=USA/O=PNPHCL</name></wassignedby>
 <body><richtext>

--- a/notes/Forms/Design Element Profile.form
+++ b/notes/Forms/Design Element Profile.form
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <form name='Design Element Profile' alias='desElement' xmlns='http://www.lotus.com/dxl'
- version='11.0' maintenanceversion='1.0' replicaid='852586DC005D7BD2' publicaccess='false'
+ version='11.0' maintenanceversion='1.0' replicaid='852586FD00509207' publicaccess='false'
  designerversion='8.5.3' comment='Little form to store the tokens used for meeting integration'
  renderpassthrough='true'>
-<noteinfo noteid='286' unid='3C3DA40D37A4EB6B8525867600470097' sequence='6'>
+<noteinfo noteid='286' unid='3C3DA40D37A4EB6B8525867600470097' sequence='3'>
 <created><datetime>20210208T075532,07-05</datetime></created>
-<modified><datetime dst='true'>20210521T131034,10-04</datetime></modified>
-<revised><datetime dst='true'>20210521T131034,09-04</datetime></revised>
-<lastaccessed><datetime dst='true'>20210521T131034,09-04</datetime></lastaccessed>
-<addedtofile><datetime dst='true'>20210521T130116,49-04</datetime></addedtofile></noteinfo>
+<modified><datetime dst='true'>20210623T104200,40-04</datetime></modified>
+<revised><datetime dst='true'>20210623T104200,39-04</datetime></revised>
+<lastaccessed><datetime dst='true'>20210623T104200,39-04</datetime></lastaccessed>
+<addedtofile><datetime dst='true'>20210623T104013,20-04</datetime></addedtofile></noteinfo>
 <updatedby><name>CN=Devin Olson/OU=USA/O=PNPHCL</name></updatedby>
 <wassignedby><name>CN=Devin Olson/OU=USA/O=PNPHCL</name></wassignedby><code
  event='windowtitle'><formula>"Design Element Profile"</formula></code>

--- a/notes/Forms/Online Meeting Credentials.form
+++ b/notes/Forms/Online Meeting Credentials.form
@@ -1,25 +1,28 @@
 <?xml version='1.0' encoding='utf-8'?>
 <form name='Online Meeting Credentials' alias='domiCredentials' xmlns='http://www.lotus.com/dxl'
- version='11.0' maintenanceversion='1.0' replicaid='852586EF0056465C' publicaccess='false'
+ version='11.0' maintenanceversion='1.0' replicaid='852586FD00509207' publicaccess='false'
  designerversion='8.5.3' comment='Little form to store the tokens used for meeting integration'
  renderpassthrough='true'>
-<noteinfo noteid='292' unid='2F55146FB8CA5CEEB7FCE79377756591' sequence='15'>
+<noteinfo noteid='28a' unid='2F55146FB8CA5CEEB7FCE79377756591' sequence='6'>
 <created><datetime>406661211T152524,17-0745</datetime></created>
-<modified><datetime dst='true'>20210617T212401,02-04</datetime></modified>
-<revised><datetime dst='true'>20210617T212401,01-04</datetime></revised>
-<lastaccessed><datetime dst='true'>20210617T212401,01-04</datetime></lastaccessed>
-<addedtofile><datetime dst='true'>20210609T114652,29-04</datetime></addedtofile></noteinfo>
+<modified><datetime dst='true'>20210623T104556,55-04</datetime></modified>
+<revised><datetime dst='true'>20210623T104556,54-04</datetime></revised>
+<lastaccessed><datetime dst='true'>20210623T104556,54-04</datetime></lastaccessed>
+<addedtofile><datetime dst='true'>20210623T104013,35-04</datetime></addedtofile></noteinfo>
 <updatedby><name>CN=Devin Olson/OU=USA/O=PNPHCL</name></updatedby>
 <wassignedby><name>CN=Devin Olson/OU=USA/O=PNPHCL</name></wassignedby>
 <globals><code event='options'><lotusscript>Option Public
-Option Explicit 
+Option Explicit ' Think of the kittens! 
 Use "domiIntegrator" ' Domino Online Meeting Integrator 
 Use "domiConstantsBE"
+Use "domiUtilsFE" 
 %INCLUDE "lsconst.lss" 
 
 
 </lotusscript></code></globals><code event='windowtitle'><formula>"Online Meeting Credentials"</formula></code><code
- event='postopen'><lotusscript>Sub Postopen(Source As Notesuidocument)
+ event='options'><lotusscript>Option Explicit ' think of the kittens! 
+
+</lotusscript></code><code event='postopen'><lotusscript>Sub Postopen(Source As Notesuidocument)
 	Dim s As New NotesSession
 	Dim services As Variant
 	Dim doc As NotesDocument
@@ -53,7 +56,20 @@ End Sub
 		Call doc.Save(True, False, True)
 	End If
 End Sub
-</lotusscript></code>
+</lotusscript></code><code event='querysave'><lotusscript>Sub Querysave(Source As Notesuidocument, Continue As Variant)
+	On Error Goto ErrorTrap
+	
+	Call instantiateDOMIlog() ' Instantiate Logging and set options for DOMI operations
+	Continue = domiValidateOAuthToken()
+	
+ExitPoint:
+	Exit Sub 
+ErrorTrap:
+	On Error Goto 0
+	enhLogException |Action Validate OAUTH Token.|, || 
+	Messagebox Error$(), 16, |Error | &amp; Cstr(Err()) 
+	Resume ExitPoint 	
+End Sub</lotusscript></code>
 <actionbar bgcolor='#ebecf1' bordercolor='black'>
 <actionbuttonstyle bgcolor='#ebecf1'/><border style='solid' width='0px 0px 1px'
  color='#f5f5f5'/>
@@ -77,7 +93,7 @@ End Sub
 >@Command([RunAgent]; "DOMI_getSTToken")</formula></code><code event='hidewhen'><formula
 >service != "sametime"</formula></code></action></actionbar>
 <body><richtext>
-<pardef id='1' leftmargin='1in' rightmargin='0%' hide='read edit print preview previewedit notes web'><parstyle
+<pardef id='1' leftmargin='1in' rightmargin='100%' hide='read edit print preview previewedit notes web'><parstyle
  name='Hidden Text - Bold' incyclekey='true'><font size='8pt' color='green'
  style='bold' name='sans-serif'/></parstyle></pardef>
 <pardef id='2' leftmargin='1in' rightmargin='83%' hide='read edit print preview previewedit notes web mobile'/>
@@ -233,7 +249,7 @@ Yg4BAIQAAAAAAAAAAAA=
 <pardef id='4' leftmargin='1in' hide='notes web mobile'/>
 <par def='4'/>
 <table widthtype='fitwindow' minrowheight='1.1701in' leftmargin='0.7500in'
- refwidth='10.4063in'><tablecolumn width='100%'/>
+ refwidth='9.6563in'><tablecolumn width='100%'/>
 <tablerow>
 <tablecell valign='center' borderwidth='0px' bgcolor='white'>
 <pardef id='6' leftmargin='0.3361in' tabs='L0.5000in L1in L1.5000in L2in L2.5000in L3in L3.5000in L4in'
@@ -245,7 +261,7 @@ Yg4BAIQAAAAAAAAAAAA=
 <pardef id='7' tabs='L0.5000in L1in L1.5000in L2in L2.5000in L3in L3.5000in L4in'
  keepwithnext='true' keeptogether='true'/>
 <par def='7'><run><font size='1pt' color='#474747'/></run></par>
-<table widthtype='fitmargins' leftmargin='0.3361in' refwidth='10.0701in'><tablecolumn
+<table widthtype='fitmargins' leftmargin='0.3361in' refwidth='9.3201in'><tablecolumn
  width='8.9000in'/><tablecolumn width='100%'/>
 <tablerow>
 <tablecell borderwidth='0px' bgcolor='#f2f2f2'>

--- a/notes/Forms/Online Meeting Credentials.form
+++ b/notes/Forms/Online Meeting Credentials.form
@@ -3,11 +3,11 @@
  version='11.0' maintenanceversion='1.0' replicaid='852586FD00509207' publicaccess='false'
  designerversion='8.5.3' comment='Little form to store the tokens used for meeting integration'
  renderpassthrough='true'>
-<noteinfo noteid='28a' unid='2F55146FB8CA5CEEB7FCE79377756591' sequence='6'>
+<noteinfo noteid='28a' unid='2F55146FB8CA5CEEB7FCE79377756591' sequence='13'>
 <created><datetime>406661211T152524,17-0745</datetime></created>
-<modified><datetime dst='true'>20210623T104556,55-04</datetime></modified>
-<revised><datetime dst='true'>20210623T104556,54-04</datetime></revised>
-<lastaccessed><datetime dst='true'>20210623T104556,54-04</datetime></lastaccessed>
+<modified><datetime dst='true'>20210623T124256,02-04</datetime></modified>
+<revised><datetime dst='true'>20210623T124256,01-04</datetime></revised>
+<lastaccessed><datetime dst='true'>20210623T124256,01-04</datetime></lastaccessed>
 <addedtofile><datetime dst='true'>20210623T104013,35-04</datetime></addedtofile></noteinfo>
 <updatedby><name>CN=Devin Olson/OU=USA/O=PNPHCL</name></updatedby>
 <wassignedby><name>CN=Devin Olson/OU=USA/O=PNPHCL</name></wassignedby>
@@ -57,10 +57,13 @@ End Sub
 	End If
 End Sub
 </lotusscript></code><code event='querysave'><lotusscript>Sub Querysave(Source As Notesuidocument, Continue As Variant)
+	
+End Sub
+</lotusscript></code><code event='postsave'><lotusscript>Sub Postsave(Source As Notesuidocument)
 	On Error Goto ErrorTrap
 	
 	Call instantiateDOMIlog() ' Instantiate Logging and set options for DOMI operations
-	Continue = domiValidateOAuthToken()
+	If domiValidateOAuthToken() Then Call Source.Close()
 	
 ExitPoint:
 	Exit Sub 
@@ -68,32 +71,36 @@ ErrorTrap:
 	On Error Goto 0
 	enhLogException |Action Validate OAUTH Token.|, || 
 	Messagebox Error$(), 16, |Error | &amp; Cstr(Err()) 
-	Resume ExitPoint 	
+	Resume ExitPoint 		
 End Sub</lotusscript></code>
 <actionbar bgcolor='#ebecf1' bordercolor='black'>
 <actionbuttonstyle bgcolor='#ebecf1'/><border style='solid' width='0px 0px 1px'
  color='#f5f5f5'/>
 <action title='Save &amp; Close' icon='21' hide='preview read'><code event='click'><formula
->@If(@Command([FileSave]); @Command([CloseWindow]); "")</formula></code></action>
+>REM { 
+	Developer's Note: Code in the PostSave event will CLOSE the window after a successful save and validate of the OAuth Token.
+
+@If(@Command([FileSave]); @Command([CloseWindow]); "")
+};
+
+@Command([FileSave])</formula></code></action>
 <action title='Edit' icon='5' hide='edit previewedit'><code event='click'><formula
 >@Command([EditDocument])</formula></code></action>
 <action title='Close' icon='27'><code event='click'><formula>@Command([CloseWindow])</formula></code></action>
 <action title='Get OAuth Token' icon='96' hide='preview read'><code event='click'><formula
 >@Command([ToolsRunMacro]; "DOMI_getOAuthTokenFE")</formula></code><code event='hidewhen'><formula
 >"" = @Trim(service) | service = "sametime"</formula></code></action>
-<action title='Validate OAuth Token' icon='39' hide='preview read'><code event='click'><formula
->@If(@Command([FileSave]); ""; @Return(""));
-@Command([ToolsRunMacro]; "DOMI_validateOAuthTokenFE")</formula></code><code
+<action title='Validate OAuth Token' icon='39' hide='edit previewedit'><code
+ event='click'><formula>@Command([ToolsRunMacro]; "DOMI_validateOAuthTokenFE")</formula></code><code
  event='hidewhen'><formula>"" = @Trim(service) | service = "sametime" | refreshToken = ""</formula></code></action>
-<action title='Revoke OAuth Token' icon='116' hide='preview read'><code event='click'><formula
->@If(@IsNewDoc; @Command([FileSave]); "");
-@Command([ToolsRunMacro]; "DOMI_revokeOAuthTokenFE")</formula></code><code
+<action title='Revoke OAuth Token' icon='116' hide='edit previewedit'><code
+ event='click'><formula>@Command([ToolsRunMacro]; "DOMI_revokeOAuthTokenFE")</formula></code><code
  event='hidewhen'><formula>"" = @Trim(service) | service != "zoom" | refreshToken = ""</formula></code></action>
 <action title='Get Sametime Token' icon='130' hide='preview read'><code event='click'><formula
 >@Command([RunAgent]; "DOMI_getSTToken")</formula></code><code event='hidewhen'><formula
 >service != "sametime"</formula></code></action></actionbar>
 <body><richtext>
-<pardef id='1' leftmargin='1in' rightmargin='100%' hide='read edit print preview previewedit notes web'><parstyle
+<pardef id='1' leftmargin='1in' rightmargin='0%' hide='read edit print preview previewedit notes web'><parstyle
  name='Hidden Text - Bold' incyclekey='true'><font size='8pt' color='green'
  style='bold' name='sans-serif'/></parstyle></pardef>
 <pardef id='2' leftmargin='1in' rightmargin='83%' hide='read edit print preview previewedit notes web mobile'/>
@@ -249,7 +256,7 @@ Yg4BAIQAAAAAAAAAAAA=
 <pardef id='4' leftmargin='1in' hide='notes web mobile'/>
 <par def='4'/>
 <table widthtype='fitwindow' minrowheight='1.1701in' leftmargin='0.7500in'
- refwidth='9.6563in'><tablecolumn width='100%'/>
+ refwidth='12.4271in'><tablecolumn width='100%'/>
 <tablerow>
 <tablecell valign='center' borderwidth='0px' bgcolor='white'>
 <pardef id='6' leftmargin='0.3361in' tabs='L0.5000in L1in L1.5000in L2in L2.5000in L3in L3.5000in L4in'
@@ -261,7 +268,7 @@ Yg4BAIQAAAAAAAAAAAA=
 <pardef id='7' tabs='L0.5000in L1in L1.5000in L2in L2.5000in L3in L3.5000in L4in'
  keepwithnext='true' keeptogether='true'/>
 <par def='7'><run><font size='1pt' color='#474747'/></run></par>
-<table widthtype='fitmargins' leftmargin='0.3361in' refwidth='9.3201in'><tablecolumn
+<table widthtype='fitmargins' leftmargin='0.3361in' refwidth='12.0910in'><tablecolumn
  width='8.9000in'/><tablecolumn width='100%'/>
 <tablerow>
 <tablecell borderwidth='0px' bgcolor='#f2f2f2'>
@@ -368,9 +375,8 @@ Yg4BAIQAAAAAAAAAAAA=
  event='click'><formula>@Command([EditGotoField]; "refreshToken");
 @Command([EditSelectAll]);
 @Command([EditPaste]);
-@If(@Command([FileSave]); ""; @Return(""));
-@PostedCommand([ToolsRunMacro]; "DOMI_validateOAuthTokenFE")</formula></code><font
- size='9pt'/>Paste</button><run><font size='12pt' color='#474747'/></run></par></tablecell></tablerow></table>
+@Command([FileSave])</formula></code><font size='9pt'/>Paste</button><run
+><font size='12pt' color='#474747'/></run></par></tablecell></tablerow></table>
 <par def='9'><run><font size='6pt' color='#474747'/></run></par></tablecell>
 <tablecell borderwidth='0px' bgcolor='#f2f2f2'>
 <par def='10'><run><font size='9pt' style='bold' color='#474747'/></run></par></tablecell></tablerow>


### PR DESCRIPTION
Added corrections to domiUtilsFE library and Online Meeting Credentials Form for the purpose of reducing potential copy / paste errors with refresh Tokens. 

Code in PostSave event now validates the OAuth Refresh token and notifies the user of Token validity.   The Validation code needs to check / update values on **existing** document(s),  which is why it will not work (using the current back-end design elements) when called from QuerySave event. 

Tested locally and verified (in pair-programming session with @paulswithers ) 